### PR TITLE
Fix base URL not redirecting to jitsi

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,9 +5,6 @@
       let route;
 
       switch (window.location.pathname) {
-        case '/' :
-          route = '/bay_area';
-          break;
         case '/2' :
           route = '/bay_area2';
           break;

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script>
+      window.location.replace('https://meet.jit.si/bay_area');
+    </script>
+  </head>
+  <body>
+    Redirecting to <a href="https://meet.jit.si/">https://meet.jit.si/</a>...
+  </body>
+</html>


### PR DESCRIPTION
It seems that when `index.html` doesn't exist, GitHub Pages doesn't just redirect to `404.html`, but rather puts up its own page with a link to the GitHub repo and the README text:
![image](https://github.com/waterloo-rocketry/meet.website/assets/8643561/12beb56b-eaa4-4fd3-8f64-30bdd6a66f94)
Therefore, navigating to `meet.waterloorocketry.com` does not redirect to `https://meet.jit.si/bay_area` but goes to this page. To fix this, I have created an `index.html` so that the base URL goes to where it is intended, and removed the `/` matching for `404.html`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/meet.website/4)
<!-- Reviewable:end -->
