### PR TITLE
Update redirect to use conference.facil.services host

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,10 +12,10 @@
           route = window.location.pathname;
       }
 
-      window.location.replace('https://meet.jit.si' + route);
+      window.location.replace('https://conference.facil.services' + route);
     </script>
   </head>
   <body>
-    Redirecting to <a href="https://meet.jit.si/">https://meet.jit.si/</a>...
+    Redirecting to <a href="https://conference.facil.services/">https://conference.facil.services/</a>...
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script>
-      window.location.replace('https://meet.jit.si/bay_area');
+      window.location.replace('https://conference.facil.services/bay_area');
     </script>
   </head>
   <body>
-    Redirecting to <a href="https://meet.jit.si/">https://meet.jit.si/</a>...
+    Redirecting to <a href="https://conference.facil.services/">https://conference.facil.services/</a>...
   </body>
 </html>


### PR DESCRIPTION
Changed the redirect for `meet.waterloorocketry.com` from `meet.jit.si` to `conference.facil.services` (a jitsi instance hosted by the Quebec government) to deal with new restrictions imposed on the former.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/meet.website/5)
<!-- Reviewable:end -->
